### PR TITLE
Rename upstream repository

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -3,7 +3,7 @@ package goproxmoxapi_test
 import (
   "testing"
   "os"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestClientBaseAPI(t *testing.T) {

--- a/cluster_log_test.go
+++ b/cluster_log_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestRecentLogsAPI(t *testing.T) {

--- a/cluster_nexid_test.go
+++ b/cluster_nexid_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestNextIdAPI(t *testing.T) {

--- a/cluster_resources_test.go
+++ b/cluster_resources_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestClusterResourcesAPI(t *testing.T) {

--- a/cluster_status_test.go
+++ b/cluster_status_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestClusterStatusAPI(t *testing.T) {

--- a/cluster_tasks_test.go
+++ b/cluster_tasks_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestRecentTasksAPI(t *testing.T) {

--- a/domains_test.go
+++ b/domains_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestDomainAPI(t *testing.T) {

--- a/groups_test.go
+++ b/groups_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestGroupAPI(t *testing.T) {

--- a/lxc_ops_test.go
+++ b/lxc_ops_test.go
@@ -3,7 +3,7 @@ package goproxmoxapi_test
 import (
   "testing"
   "time"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestLxcOpAPI(t *testing.T) {

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -3,7 +3,7 @@ package goproxmoxapi_test
 import (
   "testing"
   "time"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestNodesAPI(t *testing.T) {

--- a/password_test.go
+++ b/password_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestPasswordAPI(t *testing.T) {

--- a/pools_test.go
+++ b/pools_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestPoolAPI(t *testing.T) {

--- a/roles_test.go
+++ b/roles_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestRolesAPI(t *testing.T) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestStorageAPI(t *testing.T) {

--- a/users_test.go
+++ b/users_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestUserAPI(t *testing.T) {

--- a/version_test.go
+++ b/version_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestVersionAPI(t *testing.T) {


### PR DESCRIPTION
The upstream repository isindir is not existent anymore, so change this
fork's import rules to the current repository in order to get it to work
again.