### PR TITLE
Getting tests to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 NOTES*
+
+# actual test config generated from testconfig.json.example
+testconfig.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Proxmox API wrapper for GoLang
 
 ** Work in progress ** - see [TODO](TODO.md) list for more information.
+
+# How to get tests to work
+
+see [`TESTING.md`](TESTING.md)

--- a/TESTING.md
+++ b/TESTING.md
@@ -5,4 +5,8 @@ In this Proxmox VE instance, you need an user with admin priviledges, which logi
 has to go in to the configuration file `testconfig.json`, for an example, please have
 a look at `testconfig.json.example`.
 
-There has to be one container present with ID `100`.
+You need the following:
+
+* one container present with ID `100`
+* Alpine Linux container template `alpine-3.5-default_20170504_amd64.tar.xz`
+* two groups `gp1` and `gp2`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,8 @@
+# Testing Overview
+
+You need a working Proxmox VE in version 5.x, just because it is the current version.
+In this Proxmox VE instance, you need an user with admin priviledges, which login data
+has to go in to the configuration file `testconfig.json`, for an example, please have
+a look at `testconfig.json.example`.
+
+There has to be one container present with ID `100`.

--- a/client_test.go
+++ b/client_test.go
@@ -9,13 +9,13 @@ import (
 func TestClientBaseAPI(t *testing.T) {
   t.Parallel()
   // test new connection
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c, err)
     t.Error()
   }
   // Test Token refresh
-  if err := c.RefreshToken(); err!=nil {
+  if err := c.RefreshToken(); err != nil {
     t.Log(c, err)
     t.Error()
   }
@@ -23,7 +23,8 @@ func TestClientBaseAPI(t *testing.T) {
 
 func TestFail_New_WrongPass(t *testing.T) {
   t.Parallel()
-  _, err := goproxmoxapi.New("root", "wrong_password", "pam", "10.255.0.5")
+  username, _, realm, host := goproxmoxapi.GetProxmoxAccess()
+  _, err := goproxmoxapi.New(username, "wrong_password", realm, host)
   if err == nil {
     t.Log(err)
     t.Error()
@@ -35,7 +36,8 @@ func TestFail_New_WrongServer(t *testing.T) {
     t.Skip("skipping long running test in console (env variable LONG_RUN_TEST not defned)")
   }
   t.Parallel()
-  _, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.6")
+  username, password, realm, _ := goproxmoxapi.GetProxmoxAccess()
+  _, err := goproxmoxapi.New(username, password, realm, "10.255.0.6")
   if err == nil {
     t.Log(err)
     t.FailNow()

--- a/client_test.go
+++ b/client_test.go
@@ -3,7 +3,7 @@ package goproxmoxapi_test
 import (
   "testing"
   "os"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestClientBaseAPI(t *testing.T) {

--- a/cluster_log.go
+++ b/cluster_log.go
@@ -8,7 +8,7 @@ type LogEntry struct {
   Pri  int    // 6
   Tag  string // "pvedaemon"
   Time float64    // 1479459397
-  UID  int    // 5327
+  UID  string // 5327
   User string // "root@pam"
 }
 

--- a/cluster_log_test.go
+++ b/cluster_log_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRecentLogsAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/cluster_log_test.go
+++ b/cluster_log_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestRecentLogsAPI(t *testing.T) {

--- a/cluster_nexid_test.go
+++ b/cluster_nexid_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestNextIdAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/cluster_nexid_test.go
+++ b/cluster_nexid_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestNextIdAPI(t *testing.T) {

--- a/cluster_resources_test.go
+++ b/cluster_resources_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestClusterResourcesAPI(t *testing.T) {

--- a/cluster_resources_test.go
+++ b/cluster_resources_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestClusterResourcesAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/cluster_status_test.go
+++ b/cluster_status_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestClusterStatusAPI(t *testing.T) {

--- a/cluster_status_test.go
+++ b/cluster_status_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestClusterStatusAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -22,7 +22,7 @@ func TestClusterStatusAPI(t *testing.T) {
     t.Error("Record number must not be less than 1")
   }
 
-  pts := goproxmoxapi.TaskEntry{ Node: "pve" }
+  pts := goproxmoxapi.TaskEntry{Node: goproxmoxapi.GetProxmoxNode()}
   ftasks, err := pts.GetFinishedTasks(c)
   if err != nil {
     t.Error(err)

--- a/cluster_tasks_test.go
+++ b/cluster_tasks_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestRecentTasksAPI(t *testing.T) {

--- a/cluster_tasks_test.go
+++ b/cluster_tasks_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRecentTasksAPI(t *testing.T) {
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/domains.go
+++ b/domains.go
@@ -9,9 +9,9 @@ type Domain struct {
   // LDAP & AD
   Server1   string  // optional - Server IP address (or DNS name)
   Server2   string  // optional - Fallback Server IP address (or DNS name)
-  Secure    string     // optional - Use secure LDAPS protocol.
+  Secure    int     // optional - Use secure LDAPS protocol.
   Default   int     // optional - Use this as default realm
-  Port      string  // optional - Server port.
+  Port      int     // optional - Server port.
   TFA       string  // optional - Use Two-factor authentication.
   // AD
   Domain    string  // optional - AD domain name

--- a/domains_test.go
+++ b/domains_test.go
@@ -9,7 +9,7 @@ func TestDomainAPI(t *testing.T) {
   t.Parallel()
 
   // Establish new session
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -23,7 +23,7 @@ func TestDomainAPI(t *testing.T) {
   }
 
   // Test getting one domain
-  _, err = (goproxmoxapi.Domain{ Realm: "pve" }).GetDomain( c )
+  _, err = (goproxmoxapi.Domain{Realm: goproxmoxapi.GetProxmoxRealm()}).GetDomain(c)
   if err != nil {
     t.Error(err)
   }
@@ -35,7 +35,7 @@ func TestDomainAPI(t *testing.T) {
     Server1: "srv1",
     Domain: "example.com",
     Comment: "Test AD domain",
-    Port: "389",
+    Port: 389,
   }
 
   err = dmn1.CreateDomain( c )
@@ -49,7 +49,7 @@ func TestDomainAPI(t *testing.T) {
   if err != nil {
     t.Error(err)
   }
-  if dmn11.Port != "389" {
+  if dmn11.Port != 389 {
     t.Error("Wrong port number obtained after creation")
   }
 
@@ -57,8 +57,8 @@ func TestDomainAPI(t *testing.T) {
   dmn2 := goproxmoxapi.Domain{
     Realm: "tst",
     Server2: "srv2",
-    Port: "636",
-    Secure: "1",
+    Port: 636,
+    Secure: 1,
   }
   err = dmn2.UpdateDomain( c )
   if err != nil {
@@ -71,7 +71,7 @@ func TestDomainAPI(t *testing.T) {
   if err != nil {
     t.Error(err)
   }
-  if dmn12.Port != "636" {
+  if dmn12.Port != 636 {
     t.Error("Wrong port number obtained after update")
   }
 
@@ -90,7 +90,7 @@ func TestDomainAPI(t *testing.T) {
     Type: "ldap",
     Server1: "srv1",
     Comment: "Test AD domain",
-    Port: "389",
+    Port: 389,
     Base_DN: "cn=users,dc=abc,dc=com",
     Bind_DN: "dc=abc,dc=com",
     User_Attr: "bindusername",
@@ -107,8 +107,8 @@ func TestDomainAPI(t *testing.T) {
     Realm: "tst",
     Server2: "srv2",
     Comment: "Test AD domain Updated",
-    Port: "636",
-    Secure: "1",
+    Port: 636,
+    Secure: 1,
     Base_DN: "cn=users,dc=example,dc=com",
     Bind_DN: "dc=example,dc=com",
     User_Attr: "bindusername",

--- a/domains_test.go
+++ b/domains_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestDomainAPI(t *testing.T) {

--- a/groups_test.go
+++ b/groups_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestGroupAPI(t *testing.T) {

--- a/groups_test.go
+++ b/groups_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGroupAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/lxc_ops_test.go
+++ b/lxc_ops_test.go
@@ -10,7 +10,7 @@ func TestLxcOpAPI(t *testing.T) {
   t.Parallel()
 
   // Establish new session
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -18,7 +18,7 @@ func TestLxcOpAPI(t *testing.T) {
 
   // define basic test lxc ct config for Lxc operations
   ct1 := goproxmoxapi.NewLxcConfig( &goproxmoxapi.LxcConfig{
-    Node: "pve",
+    Node: goproxmoxapi.GetProxmoxNode(),
     VMId: 100,
   })
 
@@ -46,7 +46,7 @@ func TestLxcOpAPI(t *testing.T) {
 
   // Wait for create operation to finish (Using Proxmox TaskStatus) and only then destroy container
   ch1 := make(chan int)
-  pts := goproxmoxapi.TaskEntry{ Node: "pve", UpId: ss }
+  pts := goproxmoxapi.TaskEntry{Node: goproxmoxapi.GetProxmoxNode(), UpId: ss}
   tsts := goproxmoxapi.TaskEntry{}
   go func() {
     for tsts, err = pts.GetTaskStatus( c ); tsts.Status != "running"; {
@@ -70,7 +70,7 @@ func TestLxcOpAPI(t *testing.T) {
 
   // Wait for create operation to finish (Using Proxmox TaskStatus) and only then destroy container
   ch1 = make(chan int)
-  pts = goproxmoxapi.TaskEntry{ Node: "pve", UpId: ss }
+  pts = goproxmoxapi.TaskEntry{Node: goproxmoxapi.GetProxmoxNode(), UpId: ss}
   go func() {
     for tsts, err = pts.GetTaskStatus( c ); tsts.Status != "stopped"; {
       if err != nil {

--- a/lxc_ops_test.go
+++ b/lxc_ops_test.go
@@ -3,7 +3,7 @@ package goproxmoxapi_test
 import (
   "testing"
   "time"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestLxcOpAPI(t *testing.T) {

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -3,6 +3,7 @@ package goproxmoxapi_test
 import (
   "testing"
   "time"
+  "strings"
   "github.com/ncerny/goproxmoxapi"
 )
 
@@ -10,7 +11,7 @@ func TestNodesAPI(t *testing.T) {
   t.Parallel()
 
   // Establish new session
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -39,21 +40,21 @@ func TestNodesAPI(t *testing.T) {
   //    pvesh create /nodes/pve/lxc -vmid 101 -hostname test -password qwerty12 \
   //      -storage local-lvm -ostemplate local:vztmpl/centos-7-default_20160205_amd64.tar.xz -memory 512 -swap 512
   ct1 := goproxmoxapi.NewLxcConfig( &goproxmoxapi.LxcConfig{
-    Node: "pve",
+    Node: goproxmoxapi.GetProxmoxNode(),
     VMId: 300,
     Password: "qwerty12",
     Storage: "local-lvm",
-    OsTemplate: "local:vztmpl/centos-7-default_20160205_amd64.tar.xz",
-    //    Pool       
-    //    Onboot     
-    //    Startup    
+    OsTemplate: "local:vztmpl/alpine-3.5-default_20170504_amd64.tar.xz",
+    //    Pool
+    //    Onboot
+    //    Startup
     //    Template: "",
     Description: "Test LXC Container",
     //RootFS: "local-lvm,size=8G",
     Arch: "amd64",
-    OsType: "centos",
-    Memory: 1024,
-    Swap: 512,
+    OsType: "alpine",
+    Memory: 128,
+    Swap: 128,
     HostName: "testct",
     SearchDomain: "example.com",
     NameServer: "4.4.4.4,10.255.0.5",
@@ -68,7 +69,7 @@ func TestNodesAPI(t *testing.T) {
 
   // Wait for create operation to finish (Using Proxmox TaskStatus) and only then destroy container
   ch1 := make(chan int)
-  pts := goproxmoxapi.TaskEntry{ Node: "pve", UpId: ss }
+  pts := goproxmoxapi.TaskEntry{Node: goproxmoxapi.GetProxmoxNode(), UpId: ss}
   tsts := goproxmoxapi.TaskEntry{}
   go func() {
     for tsts, err = pts.GetTaskStatus( c ); tsts.Status != "stopped"; {
@@ -86,7 +87,7 @@ func TestNodesAPI(t *testing.T) {
 
   // test that we can obtain a log entries for a given task
   lgs, err := pts.GetTaskLogEntries( c )
-  if err != nil || len(lgs) != 22 {
+  if err != nil || ! strings.Contains(lgs[len(lgs)-1].T, "TASK OK") {
     t.Log( lgs )
     t.Error(err)
   }
@@ -116,7 +117,7 @@ func TestNodesAPI(t *testing.T) {
 
   // Wait for Delete Container task to finish and only than return
   ch2 := make(chan int)
-  pts = goproxmoxapi.TaskEntry{ Node: "pve", UpId: ss }
+  pts = goproxmoxapi.TaskEntry{Node: goproxmoxapi.GetProxmoxNode(), UpId: ss}
   tsts = goproxmoxapi.TaskEntry{}
   go func() {
     for tsts, err = pts.GetTaskStatus( c ); tsts.Status != "stopped"; {

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -3,7 +3,7 @@ package goproxmoxapi_test
 import (
   "testing"
   "time"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestNodesAPI(t *testing.T) {

--- a/password_test.go
+++ b/password_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPasswordAPI(t *testing.T) {
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -37,7 +37,7 @@ func TestPasswordAPI(t *testing.T) {
   }
 
   // Test connection with initial pass
-  ctu1, err := goproxmoxapi.New("usertotestpass", tu1.Password, "pve", "10.255.0.5")
+  ctu1, err := goproxmoxapi.New("usertotestpass", tu1.Password, "pve", goproxmoxapi.GetProxmoxHost())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -54,17 +54,15 @@ func TestPasswordAPI(t *testing.T) {
   }
 
   // Test connection with new pass
-  cpu1, err := goproxmoxapi.New("usertotestpass", pu1.Password, "pve", "10.255.0.5")
+  cpu1, err := goproxmoxapi.New("usertotestpass", pu1.Password, "pve", goproxmoxapi.GetProxmoxHost())
   if err != nil {
     t.Log(c)
     t.Error(err)
   }
-  pvever, err := goproxmoxapi.GetVersion(cpu1)
+
+  _, err = goproxmoxapi.GetVersion(cpu1)
   if err != nil {
     t.Error(err)
-  }
-  if pvever.Version != "4.3" {
-    t.Error("Should run this test against pve version 4.3")
   }
 
   // Delete User

--- a/password_test.go
+++ b/password_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestPasswordAPI(t *testing.T) {

--- a/pools_test.go
+++ b/pools_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestPoolAPI(t *testing.T) {

--- a/pools_test.go
+++ b/pools_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestPoolAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/roles_test.go
+++ b/roles_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRolesAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/roles_test.go
+++ b/roles_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestRolesAPI(t *testing.T) {

--- a/storage.go
+++ b/storage.go
@@ -7,14 +7,14 @@ type Storage struct {
   Type                  string // Common: Storage type (dir|drbd|glusterfs|iscsi|iscsidirect|lvm|lvmthin|nfs|rbd|sheepdog|zfs|zfspool)
   Content               string // Common: Allowed content types. NOTE: the value 'rootdir' is used for Containers, and value 'images' for VMs. (images,rootdir; vztmpl,iso,backup)
   Disable               int    // Common: Flag to disable the storage. (boolean)
-  MaxFiles              string // Common: Maximal number of backup files per VM. Use '0' for unlimted.
+  MaxFiles              int    // Common: Maximal number of backup files per VM. Use '0' for unlimted.
   Shared                int    // Common: optional - Mark storage as shared. (boolean)
   Format                string // Common: optional - Default image format.
   Nodes                 string // Common: Node list
   // Directory
   //   'Shared' is not listed for this type
   Path                  string // Dir: File system path.
-  MkDir                 string // Dir: Create the directory if it doesn't exist. (boolean, default: true)
+  MkDir                 int    // Dir: Create the directory if it doesn't exist. (boolean, default: true)
   // Glusterfs
   Volume                string // Glusterfs: Glusterfs Volume.
   Server2               string // Glusterfs: Backup volfile server IP or DNS name. Requires 'server'

--- a/storage_test.go
+++ b/storage_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestStorageAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -19,8 +19,8 @@ func TestStorageAPI(t *testing.T) {
     Type: "dir",
     Content: "backup",
     Path: "/var/lib/backuptst",
-    MkDir: "1",
-    MaxFiles: "5",
+    MkDir: 1,
+    MaxFiles: 5,
   }).CreateStorage(c)
   if err != nil {
     t.Error(err)
@@ -32,7 +32,7 @@ func TestStorageAPI(t *testing.T) {
     t.Error(err)
   }
   // Tes we can update it
-  st1.MaxFiles = "6"
+  st1.MaxFiles = 6
   err = st1.UpdateStorage(c)
   if err != nil {
     t.Error(err)
@@ -41,7 +41,7 @@ func TestStorageAPI(t *testing.T) {
   if err != nil {
     t.Error(err)
   }
-  if st2.MaxFiles != "6" {
+  if st2.MaxFiles != 6 {
     t.Error("Update of the storage failed")
   }
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestStorageAPI(t *testing.T) {

--- a/testconfig.go
+++ b/testconfig.go
@@ -1,0 +1,58 @@
+package goproxmoxapi
+
+// Test Proxmox VE instance configuration
+// as a singleton according to http://marcio.io/2015/07/singleton-pattern-in-go/
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+)
+
+// ProxmoxConfig represents all needed login information
+type ProxmoxConfig struct {
+	Host     string `json:"host"`
+	User     string `json:"user"`
+	Password string `json:"password"`
+	Realm    string `json:"realm"`
+	Node     string `json:"node"`
+}
+
+var instance *ProxmoxConfig
+var once sync.Once
+
+// GetProxmoxConfigInstance loads default config
+func GetProxmoxConfigInstance() *ProxmoxConfig {
+	once.Do(func() {
+		content, err := ioutil.ReadFile("testconfig.json")
+
+		if err != nil {
+			log.Fatal(err)
+			os.Exit(1)
+		}
+		var config ProxmoxConfig
+		json.Unmarshal(content, &config)
+		instance = &config
+	})
+	return instance
+}
+
+// GetProxmoxAccess gets working proxmox ve access information
+func GetProxmoxAccess() (string, string, string, string) {
+	i := GetProxmoxConfigInstance()
+	return i.User, i.Password, i.Realm, i.Host
+}
+
+// GetProxmoxNode return the defined test node
+func GetProxmoxNode() string {
+	i := GetProxmoxConfigInstance()
+	return i.Node
+}
+
+// GetProxmoxRealm return the defined test realm
+func GetProxmoxRealm() string {
+	i := GetProxmoxConfigInstance()
+	return i.Realm
+}

--- a/testconfig.go
+++ b/testconfig.go
@@ -56,3 +56,9 @@ func GetProxmoxRealm() string {
 	i := GetProxmoxConfigInstance()
 	return i.Realm
 }
+
+// GetProxmoxHost return the defined test host
+func GetProxmoxHost() string {
+	i := GetProxmoxConfigInstance()
+	return i.Host
+}

--- a/testconfig.json.example
+++ b/testconfig.json.example
@@ -1,0 +1,7 @@
+{
+    "host":"10.255.0.5",
+    "user":"root",
+    "realm": "pam",
+    "password":"P@ssw0rd",
+    "node": "pve"
+}

--- a/users_test.go
+++ b/users_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestUserAPI(t *testing.T) {
   // Establish new session
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)

--- a/users_test.go
+++ b/users_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestUserAPI(t *testing.T) {

--- a/version_test.go
+++ b/version_test.go
@@ -1,13 +1,14 @@
 package goproxmoxapi_test
 
 import (
+  "strings"
   "testing"
   "github.com/ncerny/goproxmoxapi"
 )
 
 func TestVersionAPI(t *testing.T) {
   t.Parallel()
-  c, err := goproxmoxapi.New("root", "P@ssw0rd", "pam", "10.255.0.5")
+  c, err := goproxmoxapi.New(goproxmoxapi.GetProxmoxAccess())
   if err != nil {
     t.Log(c)
     t.Error(err)
@@ -18,7 +19,7 @@ func TestVersionAPI(t *testing.T) {
   if err != nil {
     t.Error(err)
   }
-  if pvever.Version != "4.3" {
-    t.Error("Should run this test against pve version 4.3")
+  if !strings.HasPrefix(pvever.Version, "5.1") {
+    t.Error("Should run this test against pve version 5.x, yet you have '" + pvever.Version + "'")
   }
 }

--- a/version_test.go
+++ b/version_test.go
@@ -2,7 +2,7 @@ package goproxmoxapi_test
 
 import (
   "testing"
-  "github.com/isindir/goproxmoxapi"
+  "github.com/ncerny/goproxmoxapi"
 )
 
 func TestVersionAPI(t *testing.T) {


### PR DESCRIPTION
On the base of #1, this series of commits alters the way tests are run and stripes down all hardcoded occurrences of the hostname, node name, username and password and makes them accessible though a JSON config file.

Further, some API calls changed their return value, so this is fixed, too.